### PR TITLE
DB fixes & improvements

### DIFF
--- a/models/Users.ts
+++ b/models/Users.ts
@@ -1,19 +1,27 @@
 import mongoose from 'mongoose';
 
 // UserSchema describes what our documents should look like in our User collections
-const UserSchema = new mongoose.Schema({
-  name: { type: String, required: true },
-  email: { type: String, required: true },
-  password: { type: String, required: true },
-  phone: { type: String, required: true },
-  address: { type: String, required: true },
-  isVolunteer: { type: Boolean, default: false, required: true },
-  isDonor: { type: Boolean, default: false, required: true },
-  isRequester: { type: Boolean, default: false, required: true },
-  sourceHeardFrom: { type: String, required: true },
-  ethnicity: { type: String, required: true },
-  gender: { type: String, required: true },
-  createDate: { type: Date, default: Date.now, required: true },
-});
+const UserSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true },
+    password: { type: String, required: true },
+    phone: { type: String, required: true },
+    address: { type: String, required: true },
+    isVolunteer: { type: Boolean, default: false, required: true },
+    isDonor: { type: Boolean, default: false, required: true },
+    isRequester: { type: Boolean, default: false, required: true },
+    sourceHeardFrom: { type: String, required: true },
+    ethnicity: { type: String, required: true },
+    gender: { type: String, required: true },
+  },
+  {
+    timestamps: {
+      createdAt: 'createdAt',
+      updatedAt: 'updatedAt',
+    },
+    collection: 'users',
+  }
+);
 
 export default mongoose.models.User || mongoose.model('User', UserSchema);

--- a/models/VolunteerApplications.ts
+++ b/models/VolunteerApplications.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
-// VolunteerFormSchema describes what our documents should look like in our VolunteerForm collections
-const VolunteerFormSchema = new mongoose.Schema(
+// VolunteerApplicationSchema describes what our documents should look like in our VolunteerApplication collections
+const VolunteerApplicationSchema = new mongoose.Schema(
   {
     userId: { type: mongoose.Types.ObjectId, ref: 'User', required: true },
     isApproved: { type: Boolean, default: false, required: true },
@@ -21,9 +21,9 @@ const VolunteerFormSchema = new mongoose.Schema(
       createdAt: 'createdAt',
       updatedAt: 'updatedAt',
     },
-    collection: 'volunteerForms',
+    collection: 'volunteerApplications',
   }
 );
 
-export default mongoose.models.VolunteerForm ||
-  mongoose.model('VolunteerForm', VolunteerFormSchema);
+export default mongoose.models.VolunteerApplication ||
+  mongoose.model('VolunteerApplication', VolunteerApplicationSchema);

--- a/models/VolunteerForms.ts
+++ b/models/VolunteerForms.ts
@@ -1,21 +1,29 @@
 import mongoose from 'mongoose';
 
 // VolunteerFormSchema describes what our documents should look like in our VolunteerForm collections
-const VolunteerFormSchema = new mongoose.Schema({
-  userId: { type: mongoose.Types.ObjectId, ref: 'User', required: true },
-  isApproved: { type: Boolean, default: false, required: true },
-  emergencyContact: {
-    firstName: { type: String, required: true },
-    lastName: { type: String, required: true },
-    phone: { type: String, required: true },
-    relationship: { type: String, required: true },
+const VolunteerFormSchema = new mongoose.Schema(
+  {
+    userId: { type: mongoose.Types.ObjectId, ref: 'User', required: true },
+    isApproved: { type: Boolean, default: false, required: true },
+    emergencyContact: {
+      firstName: { type: String, required: true },
+      lastName: { type: String, required: true },
+      phone: { type: String, required: true },
+      relationship: { type: String, required: true },
+    },
+    workStatus: { type: String, required: false },
+    employer: { type: String, required: false },
+    //   trackHours: {type: Boolean, default: false, required: true}
+    opportunities: [{ type: String, required: false }],
   },
-  workStatus: { type: String, required: false },
-  employer: { type: String, required: false },
-  //   trackHours: {type: Boolean, default: false, required: true}
-  opportunities: [{ type: String, required: false }],
-  createDate: { type: Date, default: Date.now },
-});
+  {
+    timestamps: {
+      createdAt: 'createdAt',
+      updatedAt: 'updatedAt',
+    },
+    collection: 'volunteerForms',
+  }
+);
 
 export default mongoose.models.VolunteerForm ||
   mongoose.model('VolunteerForm', VolunteerFormSchema);

--- a/models/VolunteerLogs.ts
+++ b/models/VolunteerLogs.ts
@@ -1,15 +1,23 @@
 import mongoose from 'mongoose';
 
 // VolunteerLogSchema describes what our documents should look like in our VolunteerLogs collections
-const VolunteerLogSchema = new mongoose.Schema({
-  school: { type: String, required: false },
-  teacher: { type: String, required: false },
-  date: { type: Date, required: true },
-  hours: { type: Number, required: true },
-  userId: { type: mongoose.Types.ObjectId, ref: 'User', required: true },
-  feedback: { type: String, required: false },
-  numBooks: { type: Number, default: 0, required: true },
-});
+const VolunteerLogSchema = new mongoose.Schema(
+  {
+    school: { type: String, required: false },
+    teacher: { type: String, required: false },
+    date: { type: Date, required: true },
+    hours: { type: Number, required: true },
+    userId: { type: mongoose.Types.ObjectId, ref: 'User', required: true },
+    feedback: { type: String, required: false },
+    numBooks: { type: Number, default: 0, required: true },
+  },
+  {
+    timestamps: {
+      createdAt: 'createdAt',
+    },
+    collection: 'volunteerLogs',
+  }
+);
 
 export default mongoose.models.VolunteerLog ||
   mongoose.model('VolunteerLog', VolunteerLogSchema);

--- a/types/database.ts
+++ b/types/database.ts
@@ -29,7 +29,7 @@ export interface VolunteerLogData {
   createdAt: Date;
 }
 
-export interface VolunteerFormData {
+export interface VolunteerApplicationData {
   _id: mongoose.Types.ObjectId;
   userId: mongoose.Types.ObjectId;
   isApproved?: boolean;

--- a/types/database.ts
+++ b/types/database.ts
@@ -42,5 +42,6 @@ export interface VolunteerFormData {
   workStatus?: string;
   employer?: string;
   opportunities?: Array<string>;
-  createDate?: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/types/database.ts
+++ b/types/database.ts
@@ -13,7 +13,8 @@ export interface UserData {
   sourceHeardFrom: string;
   ethnicity: string;
   gender: string;
-  createDate?: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface VolunteerLogData {

--- a/types/database.ts
+++ b/types/database.ts
@@ -26,6 +26,7 @@ export interface VolunteerLogData {
   userId: mongoose.Types.ObjectId;
   feedback?: string;
   numBooks?: number;
+  createdAt: Date;
 }
 
 export interface VolunteerFormData {


### PR DESCRIPTION
## Fix 1
Before, our mongoose schema would insert documents into `volunteerlogs` instead of `volunteerLogs`: 

<img width="288" alt="Screen Shot 2022-11-15 at 8 03 12 PM" src="https://user-images.githubusercontent.com/58854510/202065498-13b76bbc-27b4-4a22-a5c8-772c0323ab0f.png">

Added the `collection` option to mongoose schema to tell mongoose to use camel case. 
- For example, `const VolunteerLogSchema = new mongoose.Schema({...}, { collection: 'volunteerLogs' });` will tell mongoose to use `volunteerLogs` as the collection name. 

## Fix 2
Before, we have a `createDate` field in our schema for Users & Volunteer Logs. 

Now, we take advantage of [Mongoose's default timestamps](https://mongoosejs.com/docs/timestamps.html) option so it automatically handle that for us. 

So now our schemas look like this: 
- `Users`: createdAt & updatedAt
- `VolunteerForms`: createdAt & updatedAt
- `VolunteerLogs`: createdAt (no updatedAt because logs will likely not be modified). 