### PR TITLE
Auth redirect with getServerSideProps

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,8 @@ const customJestConfig = {
     '^@/pages/(.*)$': '<rootDir>/pages/$1',
 
     '^@/styles/(.*)$': '<rootDir>/styles/$1',
+
+    '^@/lib/(.*)$': '<rootDir>/lib/$1',
   },
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/lib/getServerSideProps.ts
+++ b/lib/getServerSideProps.ts
@@ -1,0 +1,24 @@
+import { getSession, GetSessionParams } from 'next-auth/react';
+
+// This function when exported from a page will handle redirecting to
+// the login page if the user is not logged in.
+export async function getServerSideProps(context: GetSessionParams) {
+  const session = await getSession(context);
+
+  // If the user is not logged in, redirect to the login page.
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false,
+      },
+    };
+  }
+
+  // If the user is logged in, simply return the session.
+  return {
+    props: {
+      session,
+    },
+  };
+}

--- a/pages/donate.tsx
+++ b/pages/donate.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-const Donate = () => {
+const DonatePage = () => {
   return <div>Donate</div>;
 };
 
-export default Donate;
+export default DonatePage;
+
+// perform automatic redirection to login page if user not logged in.
+export { getServerSideProps } from '@/lib/getServerSideProps';

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-const Home = () => {
+const HomePage = () => {
   return <div>HomePage</div>;
 };
 
-export default Home;
+export default HomePage;
+
+// perform automatic redirection to login page if user not logged in.
+export { getServerSideProps } from '@/lib/getServerSideProps';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useSession, signOut } from 'next-auth/react';
 import styles from '@/styles/Home.module.css';
-import LoginPage from './LoginPage';
+import LoginPage from './login';
 
 export default function Home() {
   const { data: session, status } = useSession();
@@ -18,3 +18,6 @@ export default function Home() {
     </div>
   );
 }
+
+// perform automatic redirection to login page if user not logged in.
+export { getServerSideProps } from '@/lib/getServerSideProps';

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { FieldValues, useForm } from 'react-hook-form';
-import { signIn } from 'next-auth/react';
+import { getSession, GetSessionParams, signIn } from 'next-auth/react';
 
 const LoginPage = () => {
+  // React hook form.
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm();
 
+  // Function to handle login and redirect.
   const handleLogin = async (data: FieldValues) => {
     const status = await signIn('credentials', {
-      redirect: false,
+      redirect: true,
       email: data.email,
       password: data.password,
     });
@@ -37,3 +39,24 @@ const LoginPage = () => {
 };
 
 export default LoginPage;
+
+export async function getServerSideProps(context: GetSessionParams) {
+  const session = await getSession(context);
+
+  // If the user is already logged in, redirect to the home page.
+  if (session) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: true,
+      },
+    };
+  }
+
+  // If the user is not logged in, show the login page.
+  return {
+    props: {
+      session,
+    },
+  };
+}

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Register = () => {
+const RegisterPage = () => {
   return <div>RegisterPage</div>;
 };
 
-export default Register;
+export default RegisterPage;

--- a/pages/request.tsx
+++ b/pages/request.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-const Request = () => {
+const RequestPage = () => {
   return <div>Request</div>;
 };
 
-export default Request;
+export default RequestPage;
+
+// perform automatic redirection to login page if user not logged in.
+export { getServerSideProps } from '@/lib/getServerSideProps';

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-const Settings = () => {
+const SettingsPage = () => {
   return <div>Settings</div>;
 };
 
-export default Settings;
+export default SettingsPage;
+
+// perform automatic redirection to login page if user not logged in.
+export { getServerSideProps } from '@/lib/getServerSideProps';

--- a/pages/volunteer.tsx
+++ b/pages/volunteer.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-const Volunteer = () => {
+const VolunteerPage = () => {
   return <div>VolunteerPage</div>;
 };
 
-export default Volunteer;
+export default VolunteerPage;
+
+// perform automatic redirection to login page if user not logged in.
+export { getServerSideProps } from '@/lib/getServerSideProps';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@/components/*": ["components/*"],
       "@/styles/*": ["styles/*"],
-      "@/pages/*": ["pages/*"]
+      "@/pages/*": ["pages/*"],
+      "@/lib/*": ["lib/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## What changed? 
Added `lib/getServerSideProps.ts` ([read here](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props)), which calls `getSession()` to check if user has a login session. 

If user is not logged in, it will return a `redirect` ([read here](https://nextjs.org/docs/api-reference/next.config.js/redirects)) to the `/login` route. 

If user is logged in, it will simply return the session (which is essentially no action).

## Developer Workflow
Now, say, we want to prevent users from accessing `localhost:3001/home` if they are not logged in. We add the following line at the bottom of `/pages/home.tsx`: 
```typescript
// perform automatic redirection to login page if user not logged in.
export { getServerSideProps } from '@/lib/getServerSideProps';
```

This will redirect non-logged in user to `localhost:3001/login`. But if user is logged in, then it will render the page. 