### PR TITLE
remove tag-related logic for event signup

### DIFF
--- a/pages/api/event/[id].ts
+++ b/pages/api/event/[id].ts
@@ -99,10 +99,6 @@ export default async function handler(
             // TODO: Speed this up!
             event.volunteers.splice(userIndex, 1);
             user.events.splice(eventIndex, 1);
-            // TODO: Remove the tag for user only if this tag has no relationship
-            // with other events this user did
-            // const programIndex = user.tags.indexOf(event.program);
-            // user.tags.splice(programIndex, 1);
           }
 
           // Resave both document

--- a/pages/api/event/[id].ts
+++ b/pages/api/event/[id].ts
@@ -90,11 +90,6 @@ export default async function handler(
             // TODO: Speed this up!
             event.volunteers.unshift(user._id);
             user.events.unshift(event._id);
-            if (event.program != null) {
-              if (!user.tags.includes(event.program.tagName)) {
-                user.tags.unshift(event.program.tagName);
-              }
-            }
           } else if (userIndex === -1 || eventIndex === -1) {
             throw new Error('Inconsistency between collections!');
           } else {


### PR DESCRIPTION
since now we are using tags only for events, remove tag-related logic for event sign-up since it is creating an error