### PR TITLE
Add sample API and fix fake session's user id

### DIFF
--- a/pages/api/applications.ts
+++ b/pages/api/applications.ts
@@ -38,7 +38,7 @@ export default async function handler(
 
         // query volunteerApplication by event id attributes
         const applicationResponses = await ApplicationResponse.find({
-          userId: session.user.id,
+          userId: session.user._id,
         }).populate('eventId');
 
         // get all the events that the user has applied to

--- a/pages/api/event/[id]/apply.ts
+++ b/pages/api/event/[id]/apply.ts
@@ -78,7 +78,7 @@ export default async function handler(
         await mongoSession.withTransaction(async () => {
           // insert the response to applicationResponses data
           const newResponse = new ApplicationResponse({
-            userId: session.user.id,
+            userId: session.user._id,
             status: 'pending',
             eventId: id,
             answers,

--- a/pages/api/event/[id]/submitted-application.ts
+++ b/pages/api/event/[id]/submitted-application.ts
@@ -40,7 +40,7 @@ export default async function handler(
         // query volunteerApplication by event id attributes
         // using findOne - assuming there is only one application per event per user
         const volunteerApplication = await ApplicationResponse.findOne({
-          userId: session.user.id,
+          userId: session.user._id,
           eventId: id,
         });
 

--- a/pages/api/example.ts
+++ b/pages/api/example.ts
@@ -1,0 +1,24 @@
+import { makeSessionForAPITest } from '@/utils/api-testing';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from 'next-auth';
+import { authOptions } from './auth/[...nextauth]';
+import dbConnect from '@/lib/dbConnect';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  // Get session user
+  let session =
+    (await getServerSession(req, res, authOptions)) || makeSessionForAPITest();
+
+  switch (req.method) {
+    case 'GET':
+      try {
+        res.status(200).json({ message: session.user._id });
+      } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: error });
+      }
+  }
+}

--- a/utils/api-testing.ts
+++ b/utils/api-testing.ts
@@ -5,7 +5,7 @@ export const testingAPI = false;
 
 const fakeUserSession = {
   user: {
-    id: '65ae7bbd24dc37492f2581c0',
+    _id: '65ae7bbd24dc37492f2581c0',
   },
 };
 


### PR DESCRIPTION
## New template for future backend API endpoint
* Thanks to David, now we can test our API endpoint easily. 
* Before, we have to disable our middleware and then test the API endpoint using either Thunder Client or Postman. 
* Now, we can simply set `export const testingAPI = true` in `utils/api-testing.ts` and implement the API endpoints like `pages/api/example.ts`. Then you can test the endpoints using Thunder Client or Postman. 
* Just make sure you never commit `export const testingAPI = true` to remote. 